### PR TITLE
fixes rust dependency position been on the incorrect line

### DIFF
--- a/lua/dependency_assist/rust/init.lua
+++ b/lua/dependency_assist/rust/init.lua
@@ -50,7 +50,7 @@ local function report_outdated_packages(dependencies, lines, callback)
         local version = pkg.crate.newest_version
         local name = pkg.crate.name
         for lnum, line in ipairs(lines) do
-          if line:match(name) then
+          if line:match("^[%s]*" .. name .. "[%s]*=") then
             callback(lnum - 1, version)
           end
         end

--- a/lua/dependency_assist/rust/init.lua
+++ b/lua/dependency_assist/rust/init.lua
@@ -51,7 +51,7 @@ local function report_outdated_packages(dependencies, lines, callback)
         local name = pkg.crate.name
         for lnum, line in ipairs(lines) do
           if line:match(name) then
-            callback(lnum, version)
+            callback(lnum - 1, version)
           end
         end
       end


### PR DESCRIPTION
Got some free time on my hand and was able to fix the issue related to this ticket: https://github.com/akinsho/dependency-assist.nvim/issues/3. 